### PR TITLE
fix: bump news CDC producer max.request.size to 10 MB

### DIFF
--- a/apps/ingestion/connector-bootstrap/news/news-connector.json
+++ b/apps/ingestion/connector-bootstrap/news/news-connector.json
@@ -29,7 +29,7 @@
     "producer.override.buffer.memory": "536870912",
     "producer.override.batch.size": "524288",
     "producer.override.linger.ms": "100",
-    "producer.override.max.request.size": "2097152",
+    "producer.override.max.request.size": "10485760",
     "producer.override.max.block.ms": "300000",
     "producer.override.request.timeout.ms": "120000",
     "producer.override.delivery.timeout.ms": "300000",

--- a/stack-runbook.md
+++ b/stack-runbook.md
@@ -319,7 +319,7 @@ docker-compose --profile backbone --profile serving --profile source --profile p
 | `service "X" depends on undefined service "Y"` | Always include all required profiles in the `up` command |
 | Spark driver exits with `Permission denied` on `.py` file | Blank line inside `bash -lc '...'` YAML block — the `.py` path was being run as a separate shell command instead of passed to `spark-submit`. Fixed in `compose/spark-drivers.yml`. |
 | Qdrant `duplicate field max_segment_size` | Renamed env var to `MAX_SEGMENT_SIZE_KB` then removed it — see Issue 12 in `issues.md` |
-| News CDC connector FAILED with `RecordTooLargeException` | Connector config needs `producer.override.max.request.size=2097152` — see Issue 13 in `issues.md` |
+| News CDC connector FAILED with `RecordTooLargeException` | Connector config needs `producer.override.max.request.size=10485760` (10 MB, matching broker limit) — see Issue 13 in `issues.md` |
 | Postgres projector loops on `Temporary failure in name resolution` | Image is stale (still uses `PHASE3_POSTGRES_DSN`). Rebuild with `--build` — see Issue 14 |
 | Clone-news rebuild sends 400 MB of context | Build context now scoped to `infrastructure/docker/clone-news/` — see Issue 15 |
 


### PR DESCRIPTION
RecordTooLargeException for a 2.5 MB record exceeded the previous 2 MB limit. Kafka brokers already accept 10 MB (KAFKA_MESSAGE_MAX_BYTES), so align the Debezium producer override to match.